### PR TITLE
Implement MRU cache

### DIFF
--- a/internal/cache/mru/mru_cache.go
+++ b/internal/cache/mru/mru_cache.go
@@ -99,7 +99,7 @@ func (m *MRU) Contains(key string) bool {
 	return ok
 }
 
-// NewMRU creates a new LRU cache with the maximum size based on configuration.
+// NewMRU creates a new MRU cache with the maximum size based on configuration.
 func NewMRU(limit int) *MRU {
 	if limit <= 0 {
 		panic("cache limit must be greater than 0")

--- a/internal/cache/mru/mru_cache.go
+++ b/internal/cache/mru/mru_cache.go
@@ -1,0 +1,114 @@
+package mru
+
+import (
+	"sync"
+
+	"github.com/raghavgh/gofast/internal/ds/linkedlist"
+)
+
+/*
+MRU represetns a thread-safe, most recently used cache.
+When a new item gets added, it will be the very first item in the cache
+When a item get updated, it will move to the first place of the cache
+When cache reach it's limit, it will remove the first item
+*/
+type MRU struct {
+	items    map[string]*linkedlist.Node
+	eviction *linkedlist.LinkedList
+	limit    int
+	mu       *sync.RWMutex
+}
+
+// entry is used to hold a value in the eviction list.
+// we are keeping entry as value to make sure that we can access key in O(1) time
+// when we want to remove an entry from the map.
+type entry struct {
+	key   string
+	value any
+}
+
+// Get retrieves a value from the cache for a specific key.
+// And move the item to the front
+func (m *MRU) Get(key string) (any, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if node, ok := m.items[key]; ok {
+		m.eviction.MoveToFront(node)
+		return node.Val.(*entry).value, true
+	}
+
+	return nil, false
+}
+
+// Put add or update the key-value pair to the cache.
+// And move the item to front
+func (m *MRU) Put(key string, val any) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if element, ok := m.items[key]; ok {
+		m.eviction.MoveToFront(element)
+		element.Val.(*entry).value = val
+		return
+	}
+
+	if m.eviction.Len() >= m.limit {
+		delete(m.items, m.eviction.Head.Val.(*entry).key)
+		m.eviction.Remove(m.eviction.Head)
+	}
+
+	m.eviction.PushFront(&entry{key: key, value: val})
+	m.items[key] = m.eviction.Head
+}
+
+// Remove deletes a specific key-value pair from the cache.
+func (m *MRU) Remove(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if node, ok := m.items[key]; ok {
+		delete(m.items, key)
+		m.eviction.Remove(node)
+	}
+}
+
+// Len returns the number of items in the cache.
+func (m *MRU) Len() int {
+	m.mu.RLock()
+	defer m.mu.Unlock()
+
+	return m.eviction.Len()
+}
+
+// Clear removes all items from the cache.
+func (m *MRU) Clear() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.items = make(map[string]*linkedlist.Node)
+	m.eviction = linkedlist.New()
+}
+
+// Contains checks if a key is present in the cache.
+func (m *MRU) Contains(key string) bool {
+	m.mu.RLock()
+	defer m.mu.Unlock()
+
+	_, ok := m.items[key]
+	return ok
+}
+
+// NewMRU creates a new LRU cache with the maximum size based on configuration.
+func NewMRU(limit int) *MRU {
+	if limit <= 0 {
+		panic("cache limit must be greater than 0")
+	}
+
+	return &MRU{
+		items:    make(map[string]*linkedlist.Node, limit),
+		eviction: linkedlist.New(),
+		limit:    limit,
+		mu:       &sync.RWMutex{},
+	}
+}

--- a/internal/cache/mru/mru_cache.go
+++ b/internal/cache/mru/mru_cache.go
@@ -76,7 +76,7 @@ func (m *MRU) Remove(key string) {
 // Len returns the number of items in the cache.
 func (m *MRU) Len() int {
 	m.mu.RLock()
-	defer m.mu.Unlock()
+	defer m.mu.RUnlock()
 
 	return m.eviction.Len()
 }
@@ -93,7 +93,7 @@ func (m *MRU) Clear() {
 // Contains checks if a key is present in the cache.
 func (m *MRU) Contains(key string) bool {
 	m.mu.RLock()
-	defer m.mu.Unlock()
+	defer m.mu.RUnlock()
 
 	_, ok := m.items[key]
 	return ok

--- a/internal/cache/mru/mru_cache_test.go
+++ b/internal/cache/mru/mru_cache_test.go
@@ -1,0 +1,119 @@
+package mru
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestCache(t *testing.T) {
+	cache := NewMRU(1000)
+
+	t.Run("Put and Get", func(t *testing.T) {
+		key := "key1"
+		value := "value1"
+		cache.Put(key, value)
+
+		v, ok := cache.Get(key)
+		if !ok || v != value {
+			t.Errorf("Expected value %v, got %v", value, v)
+		}
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		key := "key2"
+		value := "value2"
+		cache.Put(key, value)
+
+		cache.Remove(key)
+		_, ok := cache.Get(key)
+		if ok {
+			t.Errorf("Expected key %s to be removed", key)
+		}
+	})
+
+	t.Run("Clear", func(t *testing.T) {
+		cache.Put("key", "value")
+
+		cache.Clear()
+		if cache.Len() != 0 {
+			t.Errorf("Expected cache to be cleared")
+		}
+	})
+
+	t.Run("Contains", func(t *testing.T) {
+		key := "key3"
+		value := "value3"
+		cache.Put(key, value)
+
+		if !cache.Contains(key) {
+			t.Errorf("Expected cache to contain key %s", key)
+		}
+	})
+
+	t.Run("Evict", func(t *testing.T) {
+		cache.Clear()
+
+		for i := 0; i < cache.limit; i++ {
+			key := strconv.Itoa(i)
+			cache.Put(key, "value")
+		}
+
+		// This should trigger an eviction of key "0"
+		cache.Put("new", "value")
+
+		mostRecentAddedItemKey := strconv.Itoa(cache.limit - 1)
+		_, ok := cache.Get(mostRecentAddedItemKey)
+		if ok {
+			t.Errorf("Expected key '0' to be evicted")
+		}
+	})
+
+	t.Run("UpdateExistingKey", func(t *testing.T) {
+		key := "key1"
+		initialVal := "value1"
+		updatedVal := "value2"
+		cache.Put(key, initialVal)
+
+		cache.Put(key, updatedVal) // Updating the value of the existing key
+
+		v, ok := cache.Get(key)
+		if !ok || v != updatedVal {
+			t.Errorf("Expected updated value %v, got %v", updatedVal, v)
+		}
+	})
+
+	t.Run("Evict", func(t *testing.T) {
+		cache.Clear()
+
+		for i := 0; i < cache.limit; i++ {
+			key := strconv.Itoa(i)
+			cache.Put(key, "value")
+		}
+
+		// This should replace the value of key "0" rather than evicting it
+		cache.Put("0", "newValue")
+
+		v, ok := cache.Get("0")
+		if !ok || v != "newValue" {
+			t.Errorf("Expected key '0' to be updated rather than evicted")
+		}
+	})
+}
+
+func TestCache_Concurrent(t *testing.T) {
+	cache := NewMRU(1000)
+
+	t.Run("Concurrent Get and Put", func(t *testing.T) {
+		for i := 0; i < 1000; i++ {
+			go cache.Put("key", "value")
+			go cache.Get("key")
+		}
+	})
+
+	t.Run("Concurrent Remove", func(t *testing.T) {
+		for i := 0; i < 1000; i++ {
+			go cache.Put("key", "value")
+			go cache.Remove("key")
+		}
+	})
+}

--- a/internal/cache/mru/mru_cache_test.go
+++ b/internal/cache/mru/mru_cache_test.go
@@ -58,13 +58,18 @@ func TestCache(t *testing.T) {
 			cache.Put(key, "value")
 		}
 
-		// This should trigger an eviction of key "0"
+		// This should trigger an eviction of key "9"
 		cache.Put("new", "value")
 
 		mostRecentAddedItemKey := strconv.Itoa(cache.limit - 1)
 		_, ok := cache.Get(mostRecentAddedItemKey)
 		if ok {
-			t.Errorf("Expected key '0' to be evicted")
+			t.Errorf("Expected key '%s' to be evicted", mostRecentAddedItemKey)
+		}
+
+		_, ok = cache.Get("0")
+		if !ok {
+			t.Errorf("Expected key '0' to still be present")
 		}
 	})
 

--- a/internal/cache/mru/mru_load_test.go
+++ b/internal/cache/mru/mru_load_test.go
@@ -1,0 +1,45 @@
+package mru
+
+import (
+	"strconv"
+	"testing"
+)
+
+// Initialize your MRU cache
+var cache = NewMRU(1000)
+
+func BenchmarkPut(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		cache.Put("Key"+strconv.Itoa(i), i)
+	}
+}
+
+func BenchmarkGet(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		cache.Get("Key" + strconv.Itoa(i))
+	}
+}
+
+func BenchmarkRemove(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		cache.Remove("Key" + strconv.Itoa(i))
+	}
+}
+
+func BenchmarkContains(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		cache.Contains("Key" + strconv.Itoa(i))
+	}
+}
+
+func BenchmarkClear(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		cache.Clear()
+	}
+}
+
+func BenchmarkLen(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		cache.Len()
+	}
+}


### PR DESCRIPTION
> We’re currently missing an MRU (Most Recently Used) cache algorithm in our gofast caching library. If you’re interested in contributing to this feature, this is an excellent opportunity to have your code running in a live, production-ready library!
> 
> What’s MRU?
> 
> The MRU algorithm discards the most recently used items first, opposite to how LRU (Least Recently Used) works. It’s useful in certain scenarios where recently accessed data is less likely to be accessed again, such as when processing a stack of documents.
> 
> What We Expect:
> Implement the MRU algorithm with thread safety.
> Ensure consistency with the rest of the library’s cache interface.
> Write unit tests to verify the correctness and efficiency of your implementation.
> Bonus: If you’re interested, add benchmarks to measure MRU performance compared to LRU and FIFO.
> 

This will resolve issue #12 